### PR TITLE
CPU: Add NMI support and fix processor status instructions

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -323,6 +323,15 @@ CPU::AddressOperandType CPU::getAddressOperand(MemoryAccessMode mode)
     return mA;
 }
 
+void CPU::NMI()
+{
+    pushWord(mPC);
+    pushByte((u8)mP | 0x30);
+    mClockCycle += 7;
+
+    mPC = Bus::the().readMemory16Bits(0xfffa);
+}
+
 
 u8 CPU::decode8Bits()
 {
@@ -715,7 +724,7 @@ void CPU::RTS(MemoryAccessMode)
 }
 void CPU::RTI(MemoryAccessMode)
 {
-    mP = (ProcessorStatus)popByte();
+    mP = (ProcessorStatus)((popByte() & 0xef) | ((u8)mP & 0x10) | 0x20);
     mPC = popWord();
 #if DEBUG
     printf("RTI happens and I pop to %08x\n", mPC);
@@ -782,7 +791,7 @@ void CPU::SED(MemoryAccessMode)
 
 void CPU::PHP(MemoryAccessMode)
 {
-    pushByte((u8)mP);
+    pushByte((u8)mP | 0x30);
 #if DEBUG
     printf("Status being pushed: %u\n", mP);
 #endif
@@ -801,7 +810,7 @@ void CPU::PLA(MemoryAccessMode)
 }
 void CPU::PLP(MemoryAccessMode)
 {
-    mP = (ProcessorStatus)popByte();
+    mP = (ProcessorStatus)((popByte() & 0xef) | ((u8)mP & 0x10) | 0x20);
 #if DEBUG
     printf("Status being popped: %08x\n", mA);
 #endif

--- a/cpu.h
+++ b/cpu.h
@@ -126,7 +126,6 @@ public:
     };
     void normallyIncrementClockCycle(MemoryAccessMode mode, bool pageCrossed = false);
 
-    bool nmiPending() const { return mNMIPending; }
     void NMI();
     ProcessorStatus& P() { return mP; }
     u8& SP() { return mSP; }
@@ -237,7 +236,6 @@ private:
     u8 mA;
     u8 mX;
     u8 mY;
-    bool mNMIPending { false };
 
     bool mIsRunning;
     

--- a/cpu.h
+++ b/cpu.h
@@ -126,7 +126,8 @@ public:
     };
     void normallyIncrementClockCycle(MemoryAccessMode mode, bool pageCrossed = false);
 
-    
+    bool nmiPending() const { return mNMIPending; }
+    void NMI();
     ProcessorStatus& P() { return mP; }
     u8& SP() { return mSP; }
     u16& PC() { return mPC; }
@@ -236,6 +237,7 @@ private:
     u8 mA;
     u8 mX;
     u8 mY;
+    bool mNMIPending { false };
 
     bool mIsRunning;
     


### PR DESCRIPTION
This adds support for NMI with the public CPU::NMI() member function, and the getter nmiPending() which returns whether or not an NMI instruction is pending. The instruction I wrote increments the clock cycle by 7 automatically. I also made the processor status functions conform to the specifications.