### PR TITLE
CPU: Fix BRK to not exit the system, also make nestesting slightly ea…

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -13,7 +13,11 @@ void CPU::reset()
     mA = mX = mY = 0;
     mSP = 0xfd;
     mIsRunning = true;
-    mPC = Bus::the().readMemory16Bits(Bus::the().pcStartPoint());//Bus::the().ramStart();//0xc000;
+#if TEST_ROM
+    mPC = 0xc000;
+#else
+    mPC = Bus::the().readMemory16Bits(Bus::the().pcStartPoint());
+#endif
     mClockCycle = 0;
 }
 
@@ -346,22 +350,22 @@ u16 CPU::decode16Bits()
 
 void CPU::BRK(MemoryAccessMode)
 {
+
+    setProcessorStatus(ProcessorStatus::InterruptDisable);
+
+    pushWord(mPC + 1);
+
     setProcessorStatus(ProcessorStatus::BreakCommand);
-#if DEBUG
-    printf("Do I happen as intended at BRK?\n");
-#endif
-    pushWord(mPC + 1); // ?
     pushByte((byte)mP);
+    clearProcessorStatus(ProcessorStatus::BreakCommand);
 
     mPC = Bus::the().readMemory16Bits(0xfffe);
-    setProcessorStatus(ProcessorStatus::InterruptDisable);
     
     mClockCycle += 7;
 #if DEBUG
     printf("Break happens!\n");
 #endif
     // How should BRK quit the system if at all?
-    exit(1);
 }
 
 void CPU::PHA(MemoryAccessMode)


### PR DESCRIPTION
…sier

This makes BRK work properly, though there is no way to test it except through real programs. This commit also makes TEST_ROM toggle the proper starting point for the nestest rom without having to juggle commented out starting values. Just set TEST_ROM to 1 if using the test rom, 0 for normal roms.